### PR TITLE
Fix PHP mkdir permission issues on application/logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,10 @@ cache.properties
 build
 vendor/
 composer.phar
-application/logs/
+
+*/config/development
+*/logs/log-*.php
+!*/logs/index.html
+*/cache/*
+!*/cache/index.html
+!*/cache/.htaccess


### PR DESCRIPTION
I'm having error after `composer install` at `core/logs` dir. This error:
![screenshot from 2017-01-28 15-04-16](https://cloud.githubusercontent.com/assets/9590878/22395268/160201ee-e56b-11e6-8c33-98815bc69d64.png)

This happens  because PHP unable to create directory `logs/` in applications/`.

CI's `.gitignore` is referenced from: https://github.com/github/gitignore/blob/master/CodeIgniter.gitignore