### PR TITLE
Installation for Kenji's Twig Library

### DIFF
--- a/bin/install.php
+++ b/bin/install.php
@@ -88,6 +88,16 @@ class Installer
                 'msg'   => 'See https://github.com/kenjis/codeigniter3-filename-checker',
                 'example_branch' => 'master',
             ),
+            'twig' => array(
+                'site'  => 'github',
+                'user'  => 'kenjis',
+                'repos' => 'codeigniter-ss-twig',
+                'name'  => 'CodeIgniter3 Simple and Secure Twig Integration',
+                'dir'   => 'libraries',
+                'msg'   => 'See https://github.com/kenjis/codeigniter-ss-twig',
+                'require' => array("twig/twig", "~1.22"),
+                'example_branch' => 'master',
+            ),
         );
     }
 
@@ -134,6 +144,21 @@ class Installer
 
         $this->recursiveCopy($src, $dst);
         $this->recursiveUnlink($this->tmp_dir);
+
+        // install package needed by this library (if any)
+        if (array_key_exists('require',$this->packages[$package])) {
+            $input = file_get_contents( __DIR__."/../composer.json");
+            $composer = json_decode($input);
+
+            $require = $this->packages[$package]['require'][0];
+            $composer->require->$require = $this->packages[$package]['require'][1];
+
+            $output = json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            copy(__DIR__."/../composer.json", __DIR__."/../composer.json.save");
+            file_put_contents(__DIR__."/../composer.json", $output);
+            echo 'Installing package: ' . $this->packages[$package]['name'] . PHP_EOL;
+            passthru('composer update');
+        }
 
         $msg = 'Installed: ' . $package .PHP_EOL;
         if (isset($this->packages[$package]['msg'])) {


### PR DESCRIPTION
This additional code is for install CI libraries that depend on other package.
For example: https://github.com/kenjis/codeigniter-ss-twig

### The steps are:
1. Add new package definition to array `$this->packages`, with a new key `'require'`. 
2. Method install will doing additional task: Update `composer.json` with new requirement and then run `composer update`.

### Test result:
```
$ ./bin/install.php twig master
Downloaded: https://github.com/kenjis/codeigniter-ss-twig/archive/master.zip
copied: /media/windows/Web/codeigniter-composer-installer-demo/application/libraries/Twig.php
Installing package: CodeIgniter3 Simple and Secure Twig Integration
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Generating autoload files
Installed: twig
See https://github.com/kenjis/codeigniter-ss-twig
```

Thank you.


#21 