### PR TITLE
Fixed bug that installation failed.

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -29,8 +29,6 @@ class Installer
         self::recursiveCopy('vendor/codeigniter4/framework/writable', 'writable');
         self::recursiveCopy('vendor/codeigniter4/framework/tests', 'tests');
         copy('vendor/codeigniter4/framework/spark', 'spark');
-        copy('vendor/codeigniter4/framework/rewrite.php', 'rewrite.php');
-        copy('vendor/codeigniter4/framework/serve', 'serve');
         copy('vendor/codeigniter4/framework/phpunit.xml.dist', 'phpunit.xml.dist');
         copy('vendor/codeigniter4/framework/.gitignore', '.gitignore');
 
@@ -40,16 +38,6 @@ class Installer
         $contents = str_replace(
             'public $systemDirectory = \'../system\';',
             'public $systemDirectory = \'../vendor/codeigniter4/framework/system\';',
-            $contents
-        );
-        file_put_contents($file, $contents);
-
-        // Fix paths in serve
-        $file = 'serve';
-        $contents = file_get_contents($file);
-        $contents = str_replace(
-            'require_once __DIR__.\'/system/',
-            'require_once __DIR__.\'/vendor/codeigniter4/framework/system/',
             $contents
         );
         file_put_contents($file, $contents);


### PR DESCRIPTION
In CodeIgniter4 project `rewrite.php` and` serve` are no longer placed in the project root directory by the following PR.
Therefore, an error occurs in the code that is copying or editing.

https://github.com/bcit-ci/CodeIgniter4/pull/996

In the previous PR, it depended on the directory path in `rewrite.php`, but` rewrite.php` no longer depends on the directory path in the following PR.

https://github.com/bcit-ci/CodeIgniter4/pull/1105

As a result, this codeigniter-composer-installer no longer needs to copy and edit `serve` and` rewrite.php`.