### PR TITLE
Remove $ sign copy paste in commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ codeigniter/
 ### Install CodeIgniter
 
 ```
-$ composer create-project kenjis/codeigniter-composer-installer codeigniter
+composer create-project kenjis/codeigniter-composer-installer codeigniter
 ```
 
 Above command installs `public/.htaccess` to remove `index.php` in your URL. If you don't need it, please remove it.


### PR DESCRIPTION
Remove this cause $ sign is followed in bash command